### PR TITLE
Fixed Typescript type for data entities

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -83,7 +83,7 @@ declare namespace klinecharts {
     shouldOhlc?: boolean;
     shouldFormatBigNumber?: boolean;
     styles?: any;
-    extendData: (params?: any) => any | any | null;
+    extendData: ((params?: any) => any) | any | null;
   }
   
   interface TechnicalIndicatorRenderDataSource extends DataSource {}
@@ -155,7 +155,7 @@ declare namespace klinecharts {
     styles?: any;
     lock?: boolean;
     mode?: ShapeMode;
-    data?: (params?: any) => any | any | null;
+    data?: ((params?: any) => any) | any | null;
   }
   
   interface Shape extends OverrideShape {


### PR DESCRIPTION
Parentheses are needed around the lambda so that `any` and `null` are distinct return types